### PR TITLE
cookie for `/api/users/current`

### DIFF
--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -26,7 +26,8 @@ router.get('/current', function(req, res, next) {
     delete u.confirmation_token;
     u.token = req.cookies['sdsession'];
 
-    console.log(u);
+    // If the request headers contain "x-spacedeck-api-token", set a cookie named 'sdsession' with the value of "x-spacedeck-api-token".
+    if(req.headers["x-spacedeck-api-token"]) res.cookie('sdsession', req.headers["x-spacedeck-api-token"], { domain: domain, httpOnly: true });
     
     res.status(200).json(u);
   } else {

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -27,7 +27,7 @@ router.get('/current', function(req, res, next) {
     u.token = req.cookies['sdsession'];
 
     // If the request headers contain "x-spacedeck-api-token", set a cookie named 'sdsession' with the value of "x-spacedeck-api-token".
-    if(req.headers["x-spacedeck-api-token"]) res.cookie('sdsession', req.headers["x-spacedeck-api-token"], { domain: domain, httpOnly: true });
+    if(req.headers["X-Spacedeck-Auth"]) res.cookie('sdsession', req.headers["X-Spacedeck-Auth"], { domain: domain, httpOnly: true });
     
     res.status(200).json(u);
   } else {

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -26,7 +26,7 @@ router.get('/current', function(req, res, next) {
     delete u.confirmation_token;
     u.token = req.cookies['sdsession'];
 
-    // If the request headers contain "x-spacedeck-api-token", set a cookie named 'sdsession' with the value of "x-spacedeck-api-token".
+    // If the request headers contain "X-Spacedeck-Auth", set a cookie named 'sdsession' with the value of "X-Spacedeck-Auth".
     if(req.headers["X-Spacedeck-Auth"]) res.cookie('sdsession', req.headers["X-Spacedeck-Auth"], { domain: domain, httpOnly: true });
     
     res.status(200).json(u);

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -27,7 +27,7 @@ router.get('/current', function(req, res, next) {
     u.token = req.cookies['sdsession'];
 
     // If the request headers contain "X-Spacedeck-Auth", set a cookie named 'sdsession' with the value of "X-Spacedeck-Auth".
-    if(req.headers["X-Spacedeck-Auth"]) res.cookie('sdsession', req.headers["X-Spacedeck-Auth"], { domain: domain, httpOnly: true });
+    if(req.headers["x-spacedeck-auth"]) res.cookie('sdsession', req.headers["x-spacedeck-auth"], {httpOnly: true });
     
     res.status(200).json(u);
   } else {


### PR DESCRIPTION
Implemented handling of `X-Spacedeck-Auth` in request headers and setting it as `sdsession` cookie for the `/api/users/current` route.